### PR TITLE
Redesign Given Code panel with sleek styling and remove constraints text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@types/react-syntax-highlighter": "^15.5.13",
+        "highlight.js": "^11.11.1",
         "prismjs": "^1.30.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -3224,12 +3225,12 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/highlightjs-vue": {
@@ -3719,6 +3720,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lowlight/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/lru-cache": {
@@ -4279,6 +4289,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/react-syntax-highlighter/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/react-syntax-highlighter/node_modules/is-alphabetical": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@types/react-syntax-highlighter": "^15.5.13",
+    "highlight.js": "^11.11.1",
     "prismjs": "^1.30.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,9 +152,6 @@ function App() {
                   <div className='h-full flex flex-col'>
                     <CodeDisplay
                       level={currentLevel}
-                      title='Given Code'
-                      emoji='📋'
-                      headerClass='header-html'
                     />
                   </div>
                 </Panel>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -165,18 +165,15 @@ function App() {
                 </PanelResizeHandle>
 
                 <Panel defaultSize={50} minSize={25}>
-                  <div className='h-full flex flex-col'>
-                    <CodeEditor
-                      value={levelContent.editableCSS}
-                      language='css'
-                      onChange={handleCSSChange}
-                      title='Your Code'
-                      emoji='✏️'
-                      headerClass='header-css'
-                      level={currentLevel}
-                      validation={levelContent.cssValidation}
-                    />
-                  </div>
+                  <CodeEditor
+                    value={levelContent.editableCSS}
+                    language='css'
+                    onChange={handleCSSChange}
+                    title='Your Code'
+                    emoji='✏️'
+                    headerClass='header-css'
+                    validation={levelContent.cssValidation}
+                  />
                 </Panel>
               </PanelGroup>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,9 +150,7 @@ function App() {
               <PanelGroup direction='vertical'>
                 <Panel defaultSize={50} minSize={30}>
                   <div className='h-full flex flex-col'>
-                    <CodeDisplay
-                      level={currentLevel}
-                    />
+                    <CodeDisplay level={currentLevel} />
                   </div>
                 </Panel>
 

--- a/src/components/CodeDisplay.tsx
+++ b/src/components/CodeDisplay.tsx
@@ -14,9 +14,6 @@ import type { Level } from '../types';
 
 interface CodeDisplayProps {
   level: Level;
-  title: string;
-  emoji: string;
-  headerClass: string;
 }
 
 /**
@@ -25,67 +22,37 @@ interface CodeDisplayProps {
  */
 const CodeDisplay = memo(function CodeDisplay({
   level,
-  title,
-  emoji,
-  headerClass,
 }: CodeDisplayProps) {
   const { actualTheme } = useTheme();
-  const syntaxStyle = actualTheme === 'dark' ? oneDark : oneLight;
 
   return (
-    <>
-      <div className={`${headerClass} p-4`}>
-        <h3 className='font-bold text-lg flex items-center gap-3'>
-          <span className='text-2xl'>{emoji}</span>
-          <span className='text-blue-700 dark:text-blue-200'>{title}</span>
-        </h3>
-      </div>
-      <div className='flex-1 overflow-auto p-4 bg-gray-50 dark:bg-gray-900'>
+    <div className='h-full flex flex-col overflow-hidden'>
+      <div className='flex-1 overflow-auto'>
         {/* HTML Section */}
-        <div className='mb-6'>
-          <h4 className='text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2'>
-            <span className='text-base'>📝</span>
-            HTML Structure
-          </h4>
-          <div className='border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden'>
-            <SyntaxHighlighter
-              language='html'
-              style={syntaxStyle}
-              customStyle={{
-                margin: 0,
-                fontSize: '14px',
-                fontFamily:
-                  '"Victor Mono", "SF Mono", Monaco, Menlo, "Ubuntu Mono", Consolas, "Courier New", monospace',
-              }}
-            >
-              {level.initialHTML}
-            </SyntaxHighlighter>
-          </div>
+        <div className='border-b border-gray-200 dark:border-gray-700'>
+          <SyntaxHighlighter
+            language='html'
+            useInlineStyles={false}
+            className={`syntax-highlighter ${actualTheme === 'dark' ? 'dark-theme' : 'light-theme'}`}
+            wrapLongLines={true}
+          >
+            {level.initialHTML}
+          </SyntaxHighlighter>
         </div>
 
         {/* CSS Section */}
         <div>
-          <h4 className='text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2'>
-            <span className='text-base'>🎨</span>
-            Existing CSS (cannot be modified)
-          </h4>
-          <div className='border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden'>
-            <SyntaxHighlighter
-              language='css'
-              style={syntaxStyle}
-              customStyle={{
-                margin: 0,
-                fontSize: '14px',
-                fontFamily:
-                  '"Victor Mono", "SF Mono", Monaco, Menlo, "Ubuntu Mono", Consolas, "Courier New", monospace',
-              }}
-            >
-              {level.lockedCSS}
-            </SyntaxHighlighter>
-          </div>
+          <SyntaxHighlighter
+            language='css'
+            useInlineStyles={false}
+            className={`syntax-highlighter ${actualTheme === 'dark' ? 'dark-theme' : 'light-theme'}`}
+            wrapLongLines={true}
+          >
+            {level.lockedCSS}
+          </SyntaxHighlighter>
         </div>
       </div>
-    </>
+    </div>
   );
 });
 

--- a/src/components/CodeDisplay.tsx
+++ b/src/components/CodeDisplay.tsx
@@ -5,10 +5,6 @@
 
 import { memo } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import {
-  oneDark,
-  oneLight,
-} from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useTheme } from '../hooks/useTheme';
 import type { Level } from '../types';
 
@@ -20,9 +16,7 @@ interface CodeDisplayProps {
  * Simple code display component for non-editable HTML and CSS
  * Uses react-syntax-highlighter with Prism for syntax highlighting
  */
-const CodeDisplay = memo(function CodeDisplay({
-  level,
-}: CodeDisplayProps) {
+const CodeDisplay = memo(function CodeDisplay({ level }: CodeDisplayProps) {
   const { actualTheme } = useTheme();
 
   return (

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -5,7 +5,7 @@
 import Editor, { type Monaco } from '@monaco-editor/react';
 import { memo } from 'react';
 import { useTheme } from '../hooks/useTheme';
-import type { CSSValidationResult, Level } from '../types';
+import type { CSSValidationResult } from '../types';
 import type { editor } from 'monaco-editor';
 
 interface CodeEditorProps {
@@ -16,7 +16,6 @@ interface CodeEditorProps {
   emoji: string;
   headerClass: string;
   readOnly?: boolean;
-  level?: Level;
   validation?: CSSValidationResult;
 }
 
@@ -51,13 +50,12 @@ const CodeEditor = memo(function CodeEditor({
   emoji,
   headerClass,
   readOnly = false,
-  level,
   validation,
 }: CodeEditorProps) {
   const { actualTheme } = useTheme();
 
   return (
-    <>
+    <div className='h-full flex flex-col'>
       <div className={`${headerClass} p-4`}>
         <h3 className='font-bold text-lg flex items-center gap-3'>
           <span className='text-2xl'>{emoji}</span>
@@ -71,36 +69,6 @@ const CodeEditor = memo(function CodeEditor({
             {title}
           </span>
         </h3>
-
-        {/* Show constraints for CSS editor */}
-        {level && language === 'css' && (
-          <div className='mt-2 text-sm'>
-            <div className='p-2 bg-blue-50 dark:bg-blue-900/20 rounded border border-blue-200 dark:border-blue-800'>
-              <div className='font-medium text-blue-800 dark:text-blue-200 mb-1'>
-                Constraints:
-              </div>
-              <div className='text-blue-700 dark:text-blue-300'>
-                {level.constraints}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Show validation errors */}
-        {validation && !validation.isValid && (
-          <div className='mt-2 text-sm'>
-            <div className='p-2 bg-red-50 dark:bg-red-900/20 rounded border border-red-200 dark:border-red-800'>
-              <div className='font-medium text-red-800 dark:text-red-200 mb-1'>
-                Validation Errors:
-              </div>
-              {validation.errors.map((error, index) => (
-                <div key={index} className='text-red-700 dark:text-red-300'>
-                  • {error.message}
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
       </div>
       <div className='flex-1'>
         <Editor
@@ -127,7 +95,22 @@ const CodeEditor = memo(function CodeEditor({
           }}
         />
       </div>
-    </>
+      {/* Show validation errors at bottom */}
+      {validation && !validation.isValid && (
+        <div className='p-4 text-sm'>
+          <div className='p-2 bg-red-50 dark:bg-red-900/20 rounded border border-red-200 dark:border-red-800'>
+            <div className='font-medium text-red-800 dark:text-red-200 mb-1'>
+              Validation Errors:
+            </div>
+            {validation.errors.map((error, index) => (
+              <div key={index} className='text-red-700 dark:text-red-300'>
+                • {error.message}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
   );
 });
 

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -97,17 +97,13 @@ const CodeEditor = memo(function CodeEditor({
       </div>
       {/* Show validation errors at bottom */}
       {validation && !validation.isValid && (
-        <div className='p-4 text-sm'>
-          <div className='p-2 bg-red-50 dark:bg-red-900/20 rounded border border-red-200 dark:border-red-800'>
-            <div className='font-medium text-red-800 dark:text-red-200 mb-1'>
-              Validation Errors:
+        <div className='px-4 py-2 border-t border-red-300/40 dark:border-red-400/30 bg-red-50/50 dark:bg-red-500/10'>
+          {validation.errors.map((error, index) => (
+            <div key={index} className='text-xs text-red-700 dark:text-red-300 flex items-center gap-1'>
+              <span className='w-1 h-1 bg-red-500 dark:bg-red-400 rounded-full flex-shrink-0'></span>
+              {error.message}
             </div>
-            {validation.errors.map((error, index) => (
-              <div key={index} className='text-red-700 dark:text-red-300'>
-                • {error.message}
-              </div>
-            ))}
-          </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -99,7 +99,10 @@ const CodeEditor = memo(function CodeEditor({
       {validation && !validation.isValid && (
         <div className='px-4 py-2 border-t border-red-300/40 dark:border-red-400/30 bg-red-50/50 dark:bg-red-500/10'>
           {validation.errors.map((error, index) => (
-            <div key={index} className='text-xs text-red-700 dark:text-red-300 flex items-center gap-1'>
+            <div
+              key={index}
+              className='text-xs text-red-700 dark:text-red-300 flex items-center gap-1'
+            >
               <span className='w-1 h-1 bg-red-500 dark:bg-red-400 rounded-full flex-shrink-0'></span>
               {error.message}
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -296,3 +296,104 @@
 ::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.5);
 }
+
+/* Syntax highlighter variables - using official VS Code colors */
+:root {
+  --syntax-text: #383a42;
+  --syntax-bg: #fafafa;
+  --syntax-comment: #a0a1a7;
+  --syntax-tag: #e45649;
+  --syntax-attr-name: #986801;
+  --syntax-attr-value: #50a14f;
+  --syntax-string: #50a14f;
+  --syntax-property: #4078f2;
+  --syntax-selector: #a626a4;
+  --syntax-keyword: #a626a4;
+  --syntax-punctuation: #383a42;
+}
+
+.dark {
+  --syntax-text: #d4d4d4;
+  --syntax-bg: #1e1e1e;
+  --syntax-comment: #6a9955;
+  --syntax-tag: #569cd6;
+  --syntax-attr-name: #9cdcfe;
+  --syntax-attr-value: #ce9178;
+  --syntax-string: #ce9178;
+  --syntax-property: #9cdcfe;
+  --syntax-selector: #d7ba7d;
+  --syntax-keyword: #c586c0;
+  --syntax-punctuation: #d4d4d4;
+}
+
+/* Syntax highlighter styling */
+.syntax-highlighter,
+.syntax-highlighter *,
+.syntax-highlighter pre,
+.syntax-highlighter code,
+pre.syntax-highlighter,
+code.syntax-highlighter {
+  font-family:
+    'Victor Mono', 'SF Mono', Monaco, Menlo, 'Ubuntu Mono', Consolas,
+    'Courier New', monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  font-variant-ligatures: normal;
+  font-feature-settings:
+    'liga' 1,
+    'calt' 1;
+}
+
+.syntax-highlighter {
+  margin: 0;
+  padding: 16px;
+  background: var(--syntax-bg);
+  color: var(--syntax-text);
+  text-shadow: none;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* Set default color for untokenized text */
+.syntax-highlighter *,
+.syntax-highlighter span {
+  color: var(--syntax-text);
+}
+
+/* Token colors using variables */
+.syntax-highlighter .token.comment,
+.syntax-highlighter .token.prolog,
+.syntax-highlighter .token.doctype,
+.syntax-highlighter .token.cdata {
+  color: var(--syntax-comment);
+}
+
+.syntax-highlighter .token.tag {
+  color: var(--syntax-tag);
+}
+
+.syntax-highlighter .token.attr-name {
+  color: var(--syntax-attr-name);
+}
+
+.syntax-highlighter .token.attr-value,
+.syntax-highlighter .token.string {
+  color: var(--syntax-attr-value);
+}
+
+.syntax-highlighter .token.property {
+  color: var(--syntax-property);
+}
+
+.syntax-highlighter .token.selector {
+  color: var(--syntax-selector);
+}
+
+.syntax-highlighter .token.keyword {
+  color: var(--syntax-keyword);
+}
+
+.syntax-highlighter .token.punctuation {
+  color: var(--syntax-punctuation);
+}

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -48,7 +48,7 @@ describe('App Component', () => {
 
     expect(screen.getByText(/Can You Center The/)).toBeInTheDocument();
     expect(screen.getAllByTestId('monaco-editor-css')).toHaveLength(1); // CSS editor only
-    expect(screen.getByText('Given Code')).toBeInTheDocument(); // CodeDisplay component
+    expect(screen.getByText('container')).toBeInTheDocument();
     expect(screen.getByText('Your Code')).toBeInTheDocument(); // CSS editor
     expect(screen.getByText('Check')).toBeInTheDocument();
     expect(screen.getByText('Hint')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
• Remove redundant 'Constraints' text and bulky headers from CodeDisplay component  
• Move validation errors to bottom of CSS editor with minimal, sleek styling
• Implement space-efficient Given Code panel design using useInlineStyles=false approach
• Apply Victor Mono font consistently with proper CSS variable-based syntax highlighting
• Fix dark mode background and text color consistency issues

## Test plan
- [x] Verify Victor Mono font displays correctly in code panels
- [x] Test syntax highlighting works in both light and dark modes  
- [x] Confirm validation errors appear at bottom with clean styling
- [x] Check Given Code panel displays without bulky headers
- [x] Validate dark mode text is readable (no black-on-black text)

🤖 Generated with [Claude Code](https://claude.ai/code)